### PR TITLE
Fix member card layout

### DIFF
--- a/_layouts/profiles.liquid
+++ b/_layouts/profiles.liquid
@@ -3,187 +3,168 @@ layout: page
 ---
 <div class="post">
   <article>
-  <div class="container mb-5">
-
-       <div class="row mb-5 pb-4 border-bottom border-2">
+    <div class="container mb-5">
+      <div class="row mb-5 pb-4 border-bottom border-2">
         <div class="col-md-3">
-            <h4>PI's</h4>
+          <h4>PI's</h4>
         </div>
 
         <div class="col-md-12">
-            <div class="row">
-                <div class="col-6 col-md-4 fs-sm">
-                    <img class="card-img-top" src="{{ './assets/img/hni-big.jpg' | relative_url }}" alt="Haomiao Ni">
-<h5 class="mt-2">
-    Haomiao Ni, PhD
-</h5>
-<p>
-    University of Memphis<br>
-    Computer Science Dept.<br>
-    <center><a href="https://www.memphis.edu/cs/people/faculty_pages/haomiao-ni.php" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
+          <div class="row">
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/hni-big.jpg' | relative_url }}" alt="Haomiao Ni">
+              <h5 class="mt-2">Haomiao Ni, PhD</h5>
+              <p>
+                University of Memphis<br>
+                Computer Science Dept.<br>
+                <center><a href="https://www.memphis.edu/cs/people/faculty_pages/haomiao-ni.php" class="btn btn-primary center">Profile</a></center>
+              </p>
             </div>
+          </div>
         </div>
-    </div>
+      </div>
 
-    <div class="row mb-5 pb-4 border-bottom border-2">
+      <div class="row mb-5 pb-4 border-bottom border-2">
         <div class="col-md-3">
-            <h4>Co-PI's</h4>
+          <h4>Co-PI's</h4>
         </div>
 
         <div class="col-md-12">
-            <div class="row">
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/vrus-big.jpg' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Vasile Rus, PhD
-</h5>
-<p>
-    University of Memphis <br>
-    Computer Science Dept. <br>
-    <center><a href="https://www.memphis.edu/cs/people/faculty_pages/vasile-rus.php" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/santosh_kumar.jpg' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Santosh Kumar, PhD
-</h5>
-<p>
-    University of Memphis<br>
-    Computer Science Dept<br>
-    <center><a href="https://www.memphis.edu/cs/people/faculty_pages/santosh-kumar.php" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/mckenna.jpg' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Duane Mckenna, PhD
-</h5>
-<p>
-    University of Memphis<br>
-    Biology Dept<br>
-
-    <center><a href="https://www.memphis.edu/biology/people/faculty/duane-mckenna.php" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
+          <div class="row">
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/vrus-big.jpg' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Vasile Rus, PhD</h5>
+              <p>
+                University of Memphis <br>
+                Computer Science Dept. <br>
+                <center><a href="https://www.memphis.edu/cs/people/faculty_pages/vasile-rus.php" class="btn btn-primary center">Profile</a></center>
+              </p>
             </div>
-        </div>
-    </div>
-
-
-    <div class="row mb-5 pb-4 border-bottom border-2">
-        <div class="col-md-3">
-            <h3>Co-PI's</h3>
-        </div>
-
-        <div class="col-md-12">
-            <div class="row">
-                
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/preza.png' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Chrysanthe Preza, D.Sc.
-</h5>
-<p>
-    University of Memphis<br>
-    EECE Dept.<br>
-    <center><a href="https://www.memphis.edu/cirl/" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
-                
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/lanwang-big.jpg' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Lan Wang, PhD
-</h5>
-<p>
-    University of Memphis<br>
-    Computer Science Dept<br>
-      <center><a class="btn btn-primary center" href="https://www.memphis.edu/cs/people/faculty_pages/lan-wang.php">Profile</a></center>
-</p>
-                </div>
-
-                <div class="col-6 col-md-4 fs-sm">
-<img class="card-img-top" src="{{ './assets/img/ana_doblas2019.jpg' | relative_url }}" alt="Card image cap">
-<h5 class="mt-2">
-    Ana Doblas, PhD
-</h5>
-<p>
-    <!-- Department of AI and Informatics<br> -->
-    UMass Dartmouth<br>
-    EECE Dept<br>
-    <center><a href="https://www.umassd.edu/directory/adoblas/" class="btn btn-primary center">Profile</a></center>
-</p>
-                </div>
-            </div> 
-        </div>
-    </div>
-
-
-    <div class="row mb-5 pb-4 border-bottom border-2">
-        <div class="col-md-3">
-            <h3>Student Assistants</h3>
-        </div>
-
-        <div class="col-md-12">
-            <div class="row">
-                
-                <div class="col-6 col-md-4 fs-sm">
-                     <img class="card-img-top" src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/han.jpg" alt="Card image cap">
-<h5 class="mt-2">
-    Guangzeng Han
-</h5>
-<p>
-    University of Memphis <br>
-    Computer Science PhD Student<br>
-</p>
-                </div>
-                <div class="col-6 col-md-4 fs-sm">
-                    <img class="card-img-top" src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/mayira.jpg" alt="Card image cap">
-<h5 class="mt-2">
-    Mayira Sharif
-</h5>
-<p>
-    University of Memphis<br>
-    Computer Science Undergraduate <br>
-</p>
-                </div>
-            </div> 
-        </div>
-    </div>
-
-    <div class="row mb-5 pb-4 border-bottom border-2">
-        <div class="col-md-3">
-            <h3>Former Members</h3>
-        </div>
-
-        <div class="col-md-12">
-            <div class="row">
-                <div class="col-6 col-md-4 fs-sm">
-                    <img class="card-img-top" src="{{ './assets/img/xhuang7-big.jpg' | relative_url }}" alt="Xiaolei Huang">
-                    <h5 class="mt-2">Xiaolei Huang</h5>
-                    <p>
-                        Former PI<br>
-                        University of Missouri<br>
-                        EECS Department<br>
-                        <center><a href="https://engineering.missouri.edu/faculty/xiaolei-huang/" class="btn btn-primary center">Profile</a></center>
-                    </p>
-                </div>
-                <div class="col-6 col-md-4 fs-sm">
-                    <img class="card-img-top" src="{{ './assets/img/liu.jpg' | relative_url }}" alt="Weisi Liu">
-                    <h5 class="mt-2">Weisi Liu</h5>
-                    <p>
-                        Former Student Assistant<br>
-                        University of Missouri<br>
-                        EECS Department<br>
-                    </p>
-                </div>
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/santosh_kumar.jpg' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Santosh Kumar, PhD</h5>
+              <p>
+                University of Memphis<br>
+                Computer Science Dept<br>
+                <center>
+                  <a href="https://www.memphis.edu/cs/people/faculty_pages/santosh-kumar.php" class="btn btn-primary center">Profile</a>
+                </center>
+              </p>
             </div>
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/mckenna.jpg' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Duane Mckenna, PhD</h5>
+              <p>
+                University of Memphis<br>
+                Biology Dept<br>
+
+                <center><a href="https://www.memphis.edu/biology/people/faculty/duane-mckenna.php" class="btn btn-primary center">Profile</a></center>
+              </p>
+            </div>
+          </div>
         </div>
+      </div>
+
+      <div class="row mb-5 pb-4 border-bottom border-2">
+        <div class="col-md-3">
+          <h3>Co-PI's</h3>
+        </div>
+
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/preza.png' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Chrysanthe Preza, D.Sc.</h5>
+              <p>
+                University of Memphis<br>
+                EECE Dept.<br>
+                <center><a href="https://www.memphis.edu/cirl/" class="btn btn-primary center">Profile</a></center>
+              </p>
+            </div>
+
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/lanwang-big.jpg' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Lan Wang, PhD</h5>
+              <p>
+                University of Memphis<br>
+                Computer Science Dept<br>
+                <center><a class="btn btn-primary center" href="https://www.memphis.edu/cs/people/faculty_pages/lan-wang.php">Profile</a></center>
+              </p>
+            </div>
+
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top" src="{{ './assets/img/ana_doblas2019.jpg' | relative_url }}" alt="Card image cap">
+              <h5 class="mt-2">Ana Doblas, PhD</h5>
+              <p>
+                <!-- Department of AI and Informatics<br> -->
+                UMass Dartmouth<br>
+                EECE Dept<br>
+                <center><a href="https://www.umassd.edu/directory/adoblas/" class="btn btn-primary center">Profile</a></center>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-5 pb-4 border-bottom border-2">
+        <div class="col-md-3">
+          <h3>Student Assistants</h3>
+        </div>
+
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top member-card-image" src="{{ './assets/img/han.jpg' | relative_url }}" alt="Guangzeng Han">
+              <h5 class="mt-2">Guangzeng Han</h5>
+              <p>
+                University of Memphis <br>
+                Computer Science PhD Student
+              </p>
+            </div>
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top member-card-image" src="{{ './assets/img/mayira.jpg' | relative_url }}" alt="Mayira Sharif">
+              <h5 class="mt-2">Mayira Sharif</h5>
+              <p>
+                University of Memphis<br>
+                Computer Science Undergraduate
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-5 pb-4 border-bottom border-2">
+        <div class="col-md-3">
+          <h3>Former Members</h3>
+        </div>
+
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top member-card-image" src="{{ './assets/img/xhuang7-big.jpg' | relative_url }}" alt="Xiaolei Huang">
+              <h5 class="mt-2">Xiaolei Huang</h5>
+              <p>
+                Former PI<br>
+                University of Missouri<br>
+                EECS Department
+              </p>
+              <div class="text-center"><a href="https://engineering.missouri.edu/faculty/xiaolei-huang/" class="btn btn-primary">Profile</a></div>
+            </div>
+            <div class="col-6 col-md-4 fs-sm">
+              <img class="card-img-top member-card-image" src="{{ './assets/img/liu.jpg' | relative_url }}" alt="Weisi Liu">
+              <h5 class="mt-2">Weisi Liu</h5>
+              <p>
+                Former Student Assistant<br>
+                PhD Student<br>
+                University of Missouri<br>
+                EECS Department
+              </p>
+              <div class="text-center"><a href="https://weisi2580.github.io/" class="btn btn-primary">Website</a></div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-</div>
     {% if page.profiles %}
       {% for profile in page.profiles %}
         <hr>
@@ -215,30 +196,50 @@ layout: page
     {% endif %}
   </article>
 
-  <hr/>
-  
+  <hr>
+
   <h2>IT Professionals</h2>
-    <ul>
+  <ul>
     <li>Karen A Bell, Chief Info Officer • CIO Information Technology Services</li>
     <li>Roy A Passman, Dir Enterprise Infra Services • Enterprise Infrastructure Services</li>
     <li>Kristian Skjervold, Assoc Dir Research Computing • Research Computing</li>
     <li>Eric John Spangler, System Administrator • Research Computing</li>
-    </ul>
-  <hr/>
+  </ul>
+  <hr>
   <h2>Collaborating Institutions</h2>
-<div class="container px-5 py-5"> 
-    <div class="row"> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/mstate.png" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/aku.png" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/LeMoyne-Owens-Seal.jpg" width="180px" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/RustCollegeSeal.jpg" class="img-fluid"></div> 
+  <div class="container px-5 py-5">
+    <div class="row">
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/mstate.png" class="img-fluid">
+      </div>
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/aku.png" class="img-fluid">
+      </div>
+      <div class="col mx-1">
+        <img
+          src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/LeMoyne-Owens-Seal.jpg"
+          width="180px"
+          class="img-fluid"
+        >
+      </div>
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/RustCollegeSeal.jpg" class="img-fluid">
+      </div>
     </div>
-    <hr/>
-    <div class="row"> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/umiss.png" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/uarkansas.png" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/uthsc.jpg" class="img-fluid"></div> 
-      <div class="col mx-1"><img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/fedex.png" class="img-fluid"></div> 
-    </div> 
+    <hr>
+    <div class="row">
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/umiss.png" class="img-fluid">
+      </div>
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/uarkansas.png" class="img-fluid">
+      </div>
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/uthsc.jpg" class="img-fluid">
+      </div>
+      <div class="col mx-1">
+        <img src="https://raw.githubusercontent.com/itiger-cluster/itiger-cluster.github.io/master/assets/img/fedex.png" class="img-fluid">
+      </div>
+    </div>
   </div>
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -38,6 +38,13 @@ body.sticky-bottom-footer {
   }
 }
 
+.member-card-image {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  object-position: center top;
+}
+
 // TODO: redefine content layout.
 
 /******************************************************************************


### PR DESCRIPTION
## What changed

- Remove trailing line breaks from Student Assistants and Former Members cards.
- Apply a consistent square crop to member photos so cards align.
- Add Weisi Liu's PhD Student status and personal website.
- Use local image paths for student assistant portraits.
- Format the updated profile template with the repository's Prettier configuration.

## Why

The affected sections displayed extra vertical space and inconsistent portrait heights, and Weisi Liu's current role and website were missing.

## Validation

- `npx prettier _layouts/profiles.liquid _sass/_layout.scss --check`
- Balanced HTML `div` and Liquid delimiter checks
- `git diff --check`
