### PR TITLE
Prevent member headings from wrapping

### DIFF
--- a/_layouts/profiles.liquid
+++ b/_layouts/profiles.liquid
@@ -107,7 +107,7 @@ layout: page
       </div>
 
       <div class="row mb-5 pb-4 border-bottom border-2">
-        <div class="col-md-3">
+        <div class="col-12">
           <h3>Student Assistants</h3>
         </div>
 
@@ -134,7 +134,7 @@ layout: page
       </div>
 
       <div class="row mb-5 pb-4 border-bottom border-2">
-        <div class="col-md-3">
+        <div class="col-12">
           <h3>Former Members</h3>
         </div>
 


### PR DESCRIPTION
## What changed

- Expand the Student Assistants heading container from `col-md-3` to `col-12`.
- Expand the Former Members heading container from `col-md-3` to `col-12`.

## Why

The 25% desktop-width heading column was too narrow for these titles, causing automatic line wrapping.

## Validation

- `npx prettier _layouts/profiles.liquid --check`
- Balanced HTML `div` and Liquid delimiter checks
- `git diff --check`
