### PR TITLE
Remove unsafe polyfill.io dependency

### DIFF
--- a/_includes/scripts/mathjax.liquid
+++ b/_includes/scripts/mathjax.liquid
@@ -13,5 +13,4 @@
     id="MathJax-script"
     src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"
   ></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 {% endif %}


### PR DESCRIPTION
## What changed

- Remove the global `polyfill.io` ES6 script from the MathJax include.
- Keep the existing MathJax CDN script unchanged.

## Why

The external `polyfill.io` endpoint was prompting visitors for HTTP credentials on every page load and is no longer a trusted dependency.

## User impact

Visitors will no longer see the unexpected username/password dialog. Modern browsers continue to run MathJax without this legacy ES6 polyfill.

## Validation

- `npx prettier _includes/scripts/mathjax.liquid --check`
- Liquid delimiter structure check
- Confirmed no remaining `https://polyfill.io` references in site source
- `git diff --check`
